### PR TITLE
feat: --html-in-canvas flag (canvas-draw-element)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ vitexec --gpu --path /scene ./vitexec/check-scene.ts
 | `--path /scene` | Open a specific route |
 | `--config ./vite.config.ts` | Use a specific Vite config |
 | `--gpu` | Use generic GPU/WebGPU-friendly Chromium flags |
+| `--html-in-canvas` | Enable Chrome's html-in-canvas API (`canvas-draw-element`) |
 | `--browser-ws-endpoint wss://...` | Connect to a Playwright browser WebSocket endpoint |
 | `--browser-expose-network <loopback>` | Expose local network routes to a remote browser |
 | `--screenshot ./page.png` | Capture a full-page screenshot |
@@ -118,6 +119,7 @@ CLI flags take precedence over environment variables.
 | `VITEXEC_CONFIG` | `--config` |
 | `VITEXEC_PATH` | `--path` |
 | `VITEXEC_GPU` | `--gpu` |
+| `VITEXEC_HTML_IN_CANVAS` | `--html-in-canvas` |
 | `VITEXEC_TIMEOUT` | `--timeout` |
 | `VITEXEC_SCREENSHOT` | `--screenshot` |
 | `VITEXEC_RECORD` | `--record` |

--- a/packages/vitexec/src/cli.ts
+++ b/packages/vitexec/src/cli.ts
@@ -33,6 +33,7 @@ export const VITEXEC_ENV = {
   cpuProfile: "VITEXEC_CPU_PROFILE",
   gpu: "VITEXEC_GPU",
   heapSnapshot: "VITEXEC_HEAP_SNAPSHOT",
+  htmlInCanvas: "VITEXEC_HTML_IN_CANVAS",
   networkTrace: "VITEXEC_NETWORK_TRACE",
   path: "VITEXEC_PATH",
   performanceTrace: "VITEXEC_PERFORMANCE_TRACE",
@@ -48,6 +49,12 @@ export const VITEXEC_LOCAL_GPU_BROWSER_ARGS = [
 export const VITEXEC_REMOTE_GPU_BROWSER_ARGS = [
   ...VITEXEC_LOCAL_GPU_BROWSER_ARGS
 ] as const;
+export const VITEXEC_LOCAL_HTML_IN_CANVAS_BROWSER_ARGS = [
+  "--enable-blink-features=CanvasDrawElement"
+] as const;
+export const VITEXEC_REMOTE_HTML_IN_CANVAS_BROWSER_ARGS = [
+  ...VITEXEC_LOCAL_HTML_IN_CANVAS_BROWSER_ARGS
+] as const;
 
 export type RunVitexecOptions = {
   browserExposeNetwork?: string;
@@ -56,6 +63,7 @@ export type RunVitexecOptions = {
   cpuProfilePath?: string;
   gpu?: boolean;
   heapSnapshotPath?: string;
+  htmlInCanvas?: boolean;
   moduleExtension?: VitexecModuleExtension;
   networkTracePath?: string;
   path?: string;
@@ -75,6 +83,7 @@ type CliOptions = {
   cpuProfile?: string;
   gpu?: boolean;
   heapSnapshot?: string;
+  htmlInCanvas?: boolean;
   networkTrace?: string;
   path?: string;
   performanceTrace?: string;
@@ -371,21 +380,28 @@ async function launchBrowser(
 
   await ensureChromiumInstalled({ log });
 
+  const args = [
+    ...(options.gpu ? VITEXEC_LOCAL_GPU_BROWSER_ARGS : []),
+    ...(options.htmlInCanvas ? VITEXEC_LOCAL_HTML_IN_CANVAS_BROWSER_ARGS : [])
+  ];
   return chromium.launch({
     channel: "chromium",
-    args: options.gpu ? [...VITEXEC_LOCAL_GPU_BROWSER_ARGS] : undefined
+    args: args.length > 0 ? args : undefined
   });
 }
 
 export function createRemoteBrowserHeaders(
-  options: Pick<RunVitexecOptions, "gpu">
+  options: Pick<RunVitexecOptions, "gpu" | "htmlInCanvas">
 ): Record<string, string> | undefined {
-  if (!options.gpu) return undefined;
+  if (!options.gpu && !options.htmlInCanvas) return undefined;
+
+  const args = [
+    ...(options.gpu ? VITEXEC_REMOTE_GPU_BROWSER_ARGS : []),
+    ...(options.htmlInCanvas ? VITEXEC_REMOTE_HTML_IN_CANVAS_BROWSER_ARGS : [])
+  ];
 
   return {
-    "x-playwright-launch-options": JSON.stringify({
-      args: VITEXEC_REMOTE_GPU_BROWSER_ARGS
-    })
+    "x-playwright-launch-options": JSON.stringify({ args })
   };
 }
 
@@ -880,6 +896,7 @@ async function main(): Promise<void> {
     .option("--cpu-profile <path>", "write a Chrome/V8 CPU profile after the code runs")
     .option("--gpu", "use Chromium's new headless mode with GPU-friendly flags")
     .option("--heap-snapshot <path>", "write an agent-friendly heap snapshot summary after the code runs")
+    .option("--html-in-canvas", "enable Chrome's html-in-canvas API (canvas-draw-element)")
     .option("--network-trace <path>", "write a HAR network trace after the code runs")
     .option("--path <path>", "Vite page path to open")
     .option("--performance-trace <path>", "write a Chrome performance trace after the code runs")
@@ -931,6 +948,7 @@ export function createRunOptions(
     cpuProfilePath: options.cpuProfile ?? envString(env, VITEXEC_ENV.cpuProfile),
     gpu: options.gpu ?? envBoolean(env, VITEXEC_ENV.gpu),
     heapSnapshotPath: options.heapSnapshot ?? envString(env, VITEXEC_ENV.heapSnapshot),
+    htmlInCanvas: options.htmlInCanvas ?? envBoolean(env, VITEXEC_ENV.htmlInCanvas),
     moduleExtension: context.moduleExtension,
     networkTracePath: options.networkTrace ?? envString(env, VITEXEC_ENV.networkTrace),
     path: options.path ?? envString(env, VITEXEC_ENV.path),

--- a/packages/vitexec/test/cli.test.ts
+++ b/packages/vitexec/test/cli.test.ts
@@ -805,6 +805,19 @@ describe("vitexec CLI runner", () => {
     expect(output).toContain("[log] gpu mode");
   });
 
+  it("can launch with html-in-canvas mode (canvas-draw-element)", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>ready</main>"
+    });
+
+    const output = await collectVitexec(
+      "console.log('drawElementImage type:', typeof document.createElement('canvas').getContext('2d').drawElementImage)",
+      { configFile: false, root: currentProject.root, htmlInCanvas: true }
+    );
+
+    expect(output).toContain("[log] drawElementImage type: function");
+  });
+
   it("can connect to a remote Playwright browser server", async () => {
     currentProject = await createTempViteProject({
       "index.html": "<main>remote</main>"


### PR DESCRIPTION
This is a useful option for orchestrating screenshots, rendering html into offscreen canvas and grabbing the contents  for debugging or image capture. Let me know if it fits or needs anything else.

**Open question:** fold into `--gpu` instead of a separate flag? Same convenience pattern, but they're orthogonal features.

Adds `--html-in-canvas` (env `VITEXEC_HTML_IN_CANVAS`). Launches Chromium with `--enable-blink-features=CanvasDrawElement` so `ctx.drawElementImage()` works on 147+.

Mirrors `--gpu`'s shape — opt-in flag, env-var parity, local + remote args arrays. Test asserts `drawElementImage` is a function when the flag is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--html-in-canvas` CLI option to enable Chrome's canvas-draw-element behavior.
  * Added `VITEXEC_HTML_IN_CANVAS` environment variable for the same functionality.

* **Documentation**
  * Updated CLI documentation with the new option and environment variable reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drawcall-ai/vitexec/pull/1)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->