### PR TITLE
feat: adopt an existing browser/page instead of launching a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ vitexec --gpu --path /scene ./vitexec/check-scene.ts
 | `--network-trace ./network.har` | Capture network requests as HAR |
 | `--performance-trace ./performance.trace.json` | Capture a Chrome performance trace |
 | `--heap-snapshot ./heap.json` | Capture a jq-friendly decoded heap snapshot |
+| `--keep-browser-open` | Leave a `--browser-ws-endpoint` browser running after the run |
 | `--timeout 30` | Set the maximum wait time |
 
 ## Environment Variables
@@ -125,7 +126,44 @@ CLI flags take precedence over environment variables.
 | `VITEXEC_NETWORK_TRACE` | `--network-trace` |
 | `VITEXEC_PERFORMANCE_TRACE` | `--performance-trace` |
 | `VITEXEC_HEAP_SNAPSHOT` | `--heap-snapshot` |
+| `VITEXEC_KEEP_BROWSER_OPEN` | `--keep-browser-open` |
 
 When `--browser-ws-endpoint` is set, vitexec only sends browser-generic
 GPU/WebGPU launch flags. Start the remote Playwright server with any
 host-specific GPU policy that matches its platform.
+
+## Run inside a browser you already have (page adoption)
+
+By default vitexec launches its own Chromium. When you call it programmatically
+you can instead hand it a browser/context/page you already own — so the snippet
+runs in **that** browser with **no second window**. This is ideal when a dev
+server already opens a visible, instrumented tab (e.g. a WebXR emulator) and you
+want to watch the check run live in it.
+
+```ts
+import { runVitexec, runVitexecOnPage } from "vitexec/dist/cli.js";
+
+// Adopt an existing Playwright Page (same process). vitexec navigates it to its
+// own injected URL, runs the snippet, and never closes the page/context/browser.
+for await (const line of runVitexecOnPage(code, page, { root })) console.log(line);
+
+// Or pass handles directly:
+runVitexec(code, { root, page });                 // reuse this page
+runVitexec(code, { root, context });              // open a fresh page in this context
+runVitexec(code, { root, browser });              // open a fresh context+page in this browser
+runVitexec(code, { root, adoptPage: () => page }); // thunk resolved AFTER the server is listening
+```
+
+`adoptPage` is a thunk so a caller that opens the browser *in reaction to*
+vitexec's own dev server starting (a Vite plugin launching a browser on
+`listening`) can hand the page over once it exists.
+
+Ownership is automatic: when a page/context/browser is adopted, vitexec reuses it
+and never closes it (`keepBrowserOpen` is implied) — it only ever closes handles
+it created itself, and always closes its own Vite server. On the
+`--browser-ws-endpoint` path, set `keepBrowserOpen` to leave a `launchServer`
+browser running between runs.
+
+vitexec still serves the snippet from its own Vite server (that is where the
+injected module lives), so an adopted page is navigated to vitexec's per-run URL.
+A re-used page is safe to drive across many sequential runs.

--- a/packages/vitexec/src/cli.ts
+++ b/packages/vitexec/src/cli.ts
@@ -13,6 +13,7 @@ import {
   type BrowserContext,
   type CDPSession,
   type ConsoleMessage,
+  type Frame,
   type Page,
   type Request,
   type Response
@@ -38,7 +39,8 @@ export const VITEXEC_ENV = {
   performanceTrace: "VITEXEC_PERFORMANCE_TRACE",
   record: "VITEXEC_RECORD",
   screenshot: "VITEXEC_SCREENSHOT",
-  timeout: "VITEXEC_TIMEOUT"
+  timeout: "VITEXEC_TIMEOUT",
+  keepBrowserOpen: "VITEXEC_KEEP_BROWSER_OPEN"
 } as const;
 export const VITEXEC_LOCAL_GPU_BROWSER_ARGS = [
   "--enable-gpu",
@@ -64,7 +66,60 @@ export type RunVitexecOptions = {
   root?: string;
   screenshotPath?: string;
   timeoutMs?: number;
+  /**
+   * Adopt an already-open Playwright Page instead of launching/connecting a
+   * browser. The thunk is invoked AFTER vitexec's Vite server is listening, so
+   * a caller (e.g. a Vite plugin that launches a browser on `listening`) can
+   * hand over the page it just opened. vitexec navigates that page to its own
+   * per-run URL, runs the snippet, and never closes the page/context/browser.
+   * Same-process only — a Page is a live RPC proxy bound to its owning process.
+   */
+  adoptPage?: () => Page | Promise<Page>;
+  /** Adopt an already-open Page directly (same constraints as `adoptPage`). */
+  page?: Page;
+  /** Adopt a context (vitexec opens a fresh page in it) instead of newContext. */
+  context?: BrowserContext;
+  /** Adopt a browser (vitexec opens a fresh context+page) instead of launch/connect. */
+  browser?: Browser;
+  /**
+   * Never close the browser/context/page on finish or abort. Implied true when
+   * a page/context/browser is adopted; also settable on the `browserWsEndpoint`
+   * path to leave a `launchServer` browser running between runs. vitexec always
+   * still closes its own Vite server.
+   */
+  keepBrowserOpen?: boolean;
 };
+
+// One stable `__vitexecReport` binding per page, dispatching to the current
+// run's resolver. Lets a single adopted page be reused across sequential runs
+// without Playwright's "function already registered" error.
+const VITEXEC_BOUND_PAGES = new WeakSet<Page>();
+const VITEXEC_REPORT_RESOLVERS = new WeakMap<Page, () => void>();
+
+async function ensureReportBinding(page: Page): Promise<void> {
+  if (VITEXEC_BOUND_PAGES.has(page)) return;
+  VITEXEC_BOUND_PAGES.add(page);
+  try {
+    await page.exposeFunction("__vitexecReport", () => {
+      VITEXEC_REPORT_RESOLVERS.get(page)?.();
+    });
+  } catch {
+    // Already exposed on a reused page (e.g. survived a prior run). The resolver
+    // indirection means the existing binding routes to the current run — safe.
+  }
+}
+
+/**
+ * Convenience wrapper: run a snippet inside an already-open Playwright Page
+ * (e.g. a dev server's visible managed tab) without launching a second browser.
+ */
+export function runVitexecOnPage(
+  code: string,
+  page: Page,
+  options: Omit<RunVitexecOptions, "page" | "adoptPage"> = {}
+): AsyncGenerator<string> {
+  return runVitexec(code, { ...options, page, keepBrowserOpen: true });
+}
 
 type Environment = Record<string, string | undefined>;
 
@@ -81,6 +136,7 @@ type CliOptions = {
   record?: string;
   screenshot?: string;
   timeout?: number;
+  keepBrowserOpen?: boolean;
 };
 
 export async function* runVitexec(
@@ -194,7 +250,18 @@ async function runVitexecInServerTask(
   let page: Page | undefined;
   let cdp: CDPSession | undefined;
   let performanceTrace: PerformanceTraceCapture | undefined;
-  const closeBrowser = () => void browser?.close().catch(() => undefined);
+
+  // Ownership: vitexec only closes browser-tree handles it created itself. When a
+  // caller adopts an existing page/context/browser (e.g. a dev server handing
+  // over its visible managed tab), vitexec reuses it and leaves it open. vitexec
+  // always owns and closes its own Vite server (see runVitexec).
+  let ownsBrowser = false;
+  let ownsContext = false;
+  let ownsPage = false;
+  let keepOpen = options.keepBrowserOpen ?? false;
+  const closeBrowser = () => {
+    if (!keepOpen) void browser?.close().catch(() => undefined);
+  };
 
   const pendingConsoleLogs = new Set<Promise<void>>();
   const collectConsoleLog = (message: ConsoleMessage) => {
@@ -202,22 +269,67 @@ async function runVitexecInServerTask(
     pendingConsoleLogs.add(pendingLog);
     pendingLog.finally(() => pendingConsoleLogs.delete(pendingLog));
   };
+  const onPageError = (error: Error) => log(`[page error] ${error.message}`);
+  const onRequestFailed = (request: Request) => log(formatRequestFailure(request));
+  const onResponse = (response: Response) => {
+    if (response.status() >= 400) log(formatHttpError(response));
+  };
+  let hasMainFrameNavigated = false;
+  const onFrameNavigated = (frame: Frame) => {
+    if (frame !== page?.mainFrame()) return;
+    if (hasMainFrameNavigated) log(`[navigation] navigated ${frame.url()}`);
+    hasMainFrameNavigated = true;
+  };
+
   try {
-    browser = await launchBrowser(options, log);
-    signal.addEventListener("abort", closeBrowser, { once: true });
+    const adoptedPage =
+      options.page ?? (options.adoptPage ? await options.adoptPage() : undefined);
+
+    if (adoptedPage) {
+      page = adoptedPage;
+      context = page.context();
+      browser = context.browser() ?? undefined;
+      keepOpen = true;
+    } else if (options.context) {
+      context = options.context;
+      browser = context.browser() ?? undefined;
+      keepOpen = true;
+      ownsPage = true;
+      page = await context.newPage();
+    } else if (options.browser) {
+      browser = options.browser;
+      keepOpen = true;
+      ownsContext = true;
+      ownsPage = true;
+    } else {
+      browser = await launchBrowser(options, log);
+      ownsBrowser = true;
+      ownsContext = true;
+      ownsPage = true;
+      signal.addEventListener("abort", closeBrowser, { once: true });
+    }
     if (signal.aborted) return;
 
-    if (options.networkTracePath) await ensureParentDir(options.networkTracePath);
-    context = await browser.newContext({
-      ignoreHTTPSErrors: true,
-      ...(options.networkTracePath && !signal.aborted
-        ? { recordHar: { path: options.networkTracePath } }
-        : {}),
-      ...(options.recordPath && !signal.aborted
-        ? { recordVideo: { dir: dirname(options.recordPath) } }
-        : {})
-    });
-    page = await context.newPage();
+    if (ownsContext) {
+      if (options.networkTracePath) await ensureParentDir(options.networkTracePath);
+      context = await browser!.newContext({
+        ignoreHTTPSErrors: true,
+        ...(options.networkTracePath && !signal.aborted
+          ? { recordHar: { path: options.networkTracePath } }
+          : {}),
+        ...(options.recordPath && !signal.aborted
+          ? { recordVideo: { dir: dirname(options.recordPath) } }
+          : {})
+      });
+      page = await context.newPage();
+    }
+    if (!page || !context) {
+      throw new Error("vitexec could not acquire a browser page.");
+    }
+    if (!ownsContext && (options.networkTracePath || options.recordPath)) {
+      log("[skipped] --record / --network-trace require a vitexec-created context; ignored for adopted page");
+    }
+
     cdp = await context.newCDPSession(page);
     if (options.cpuProfilePath) {
       await cdp.send("Profiler.enable");
@@ -229,21 +341,24 @@ async function runVitexecInServerTask(
     page.setDefaultTimeout(timeoutMs);
     page.setDefaultNavigationTimeout(timeoutMs);
     page.on("console", collectConsoleLog);
-    page.on("pageerror", (error) => log(`[page error] ${error.message}`));
-    page.on("requestfailed", (request) => log(formatRequestFailure(request)));
-    page.on("response", (response) => {
-      if (response.status() >= 400) log(formatHttpError(response));
-    });
-    let hasMainFrameNavigated = false;
-    page.on("framenavigated", (frame) => {
-      if (frame !== page?.mainFrame()) return;
-      if (hasMainFrameNavigated) {
-        log(`[navigation] navigated ${frame.url()}`);
-      }
-      hasMainFrameNavigated = true;
-    });
+    page.on("pageerror", onPageError);
+    page.on("requestfailed", onRequestFailed);
+    page.on("response", onResponse);
+    page.on("framenavigated", onFrameNavigated);
+
     const injectedCodeFinished = createInjectedCodeCompletion(timeoutMs, signal);
-    await page.exposeFunction("__vitexecReport", injectedCodeFinished.resolve);
+    VITEXEC_REPORT_RESOLVERS.set(page, injectedCodeFinished.resolve);
+    await ensureReportBinding(page);
+
+    // An adopted page has already loaded once (its pre-existing document). The
+    // injected runtime is "armed" (see startViteServer), so arm it now — before
+    // our own navigation — so the snippet runs exactly once, on our load, after
+    // __vitexecReport is bound. Fresh owned pages are not armed.
+    if (adoptedPage) {
+      await page.addInitScript((armId) => {
+        (globalThis as Record<string, unknown>).__vitexecArm = armId;
+      }, id);
+    }
 
     const response = await page.goto(url, {
       timeout: timeoutMs,
@@ -278,13 +393,24 @@ async function runVitexecInServerTask(
         await saveHeapSnapshotSummary(cdp, options.heapSnapshotPath);
         log(`[heap-snapshot] ${options.heapSnapshotPath}`);
       }
-      if (page && options.recordPath && !signal.aborted) {
+      if (ownsContext && page && options.recordPath && !signal.aborted) {
         await saveRecording(page, options.recordPath);
         log(`[recording] ${options.recordPath}`);
       }
     } finally {
       signal.removeEventListener("abort", closeBrowser);
-      if (context) {
+      // Detach our own listeners so an adopted (reused) page does not accumulate
+      // handlers across runs; the caller's own listeners are untouched.
+      if (page) {
+        VITEXEC_REPORT_RESOLVERS.delete(page);
+        page.off("console", collectConsoleLog);
+        page.off("pageerror", onPageError);
+        page.off("requestfailed", onRequestFailed);
+        page.off("response", onResponse);
+        page.off("framenavigated", onFrameNavigated);
+      }
+      if (cdp) await cdp.detach().catch(() => undefined);
+      if (ownsContext && context) {
         await context.close().then(
           () => {
             if (options.networkTracePath && !signal.aborted) {
@@ -294,7 +420,7 @@ async function runVitexecInServerTask(
           () => undefined
         );
       }
-      await browser?.close().catch(() => undefined);
+      if (ownsBrowser && !keepOpen) await browser?.close().catch(() => undefined);
     }
   }
 }
@@ -305,6 +431,9 @@ async function startViteServer(
   options: RunVitexecOptions
 ): Promise<ViteDevServer> {
   const root = await resolveViteRootOption(options);
+  // Arm the injected runtime when we will adopt an already-loaded page, so the
+  // snippet runs only after vitexec arms+navigates it (not on its prior load).
+  const armed = Boolean(options.page || options.adoptPage);
   const server = await createServer({
     configFile: options.configFile,
     root,
@@ -317,7 +446,7 @@ async function startViteServer(
       strictPort: false,
       watch: null
     },
-    plugins: [vitexec({ code, id, moduleExtension: options.moduleExtension })]
+    plugins: [vitexec({ code, id, moduleExtension: options.moduleExtension, armed })]
   });
 
   await server.listen();
@@ -889,6 +1018,7 @@ async function main(): Promise<void> {
       "Playwright browser WebSocket endpoint to connect to instead of launching Chromium locally"
     )
     .option("--screenshot <path>", "write a full-page screenshot after the code runs")
+    .option("--keep-browser-open", "leave the connected browser running after the code finishes (for --browser-ws-endpoint)")
     .option("--timeout <seconds>", "maximum time to wait for navigation and injected code", parseTimeoutSeconds)
     .showHelpAfterError()
     .parse();
@@ -937,6 +1067,7 @@ export function createRunOptions(
     performanceTracePath: options.performanceTrace ?? envString(env, VITEXEC_ENV.performanceTrace),
     recordPath: options.record ?? envString(env, VITEXEC_ENV.record),
     screenshotPath: options.screenshot ?? envString(env, VITEXEC_ENV.screenshot),
+    keepBrowserOpen: options.keepBrowserOpen ?? envBoolean(env, VITEXEC_ENV.keepBrowserOpen),
     timeoutMs: timeout === undefined ? undefined : timeout * 1000
   };
 }

--- a/packages/vitexec/src/index.ts
+++ b/packages/vitexec/src/index.ts
@@ -10,6 +10,14 @@ export type VitexecPluginOptions = {
   code: string;
   id: string;
   moduleExtension?: VitexecModuleExtension;
+  /**
+   * When true, the injected runtime only imports the snippet after the page sets
+   * `globalThis.__vitexecArm === id`. Used when adopting an already-loaded page so
+   * the snippet does not run on the page's pre-existing load (before vitexec has
+   * exposed `__vitexecReport`). Fresh pages owned by vitexec leave this false and
+   * run unconditionally — identical to the default behavior.
+   */
+  armed?: boolean;
 };
 
 function decodeId(value: string): string | undefined {
@@ -65,12 +73,23 @@ function idFromResolvedModuleId(
   return decodeId(encodedId);
 }
 
-function runtimeScript(id: string, base: string): string {
+function runtimeScript(id: string, base: string, armed: boolean): string {
+  const run = `globalThis.__vitexecRuns[${JSON.stringify(id)}] = import(${JSON.stringify(codeRouteForBase(base))} + "/" + ${JSON.stringify(encodeURIComponent(id))})
+  .catch(console.error)
+  .finally(() => globalThis.__vitexecReport?.());`;
+
+  if (!armed) {
+    return `
+globalThis.__vitexecRuns ??= {};
+${run}
+`;
+  }
+
   return `
 globalThis.__vitexecRuns ??= {};
-globalThis.__vitexecRuns[${JSON.stringify(id)}] = import(${JSON.stringify(codeRouteForBase(base))} + "/" + ${JSON.stringify(encodeURIComponent(id))})
-  .catch(console.error)
-  .finally(() => globalThis.__vitexecReport?.());
+if (globalThis.__vitexecArm === ${JSON.stringify(id)}) {
+  ${run}
+}
 `;
 }
 
@@ -130,7 +149,7 @@ export function vitexec(options: VitexecPluginOptions): Plugin {
             attrs: {
               type: "module"
             },
-            children: runtimeScript(options.id, base),
+            children: runtimeScript(options.id, base, options.armed ?? false),
             injectTo: "head"
           }
         ]

--- a/packages/vitexec/test/cli.test.ts
+++ b/packages/vitexec/test/cli.test.ts
@@ -4,6 +4,7 @@ import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
 import { afterEach, describe, expect, it } from "vitest";
 import type { TestProject } from "./helpers.js";
 import { createTempViteProject } from "./helpers.js";
@@ -14,6 +15,7 @@ import {
   resolveVitexecCodeInputDetails,
   resolveVitexecCodeInput,
   runVitexec,
+  runVitexecOnPage,
   VITEXEC_ENV,
   VITEXEC_REMOTE_GPU_BROWSER_ARGS,
   VITEXEC_TIMEOUT_MS
@@ -822,6 +824,127 @@ describe("vitexec CLI runner", () => {
     );
 
     expect(output).toContain("[log] remote text remote");
+  });
+
+  it("adopts an existing page and leaves it (and its browser) open", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>adopt</main>"
+    });
+    const browser = await chromium.launch();
+    try {
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+      const page = await context.newPage();
+      await page.goto("about:blank");
+
+      const output = await collectVitexec(
+        "console.log('adopted', document.querySelector('main')?.textContent)",
+        { configFile: false, root: currentProject.root, page }
+      );
+
+      expect(output).toContain("[log] adopted adopt");
+      // vitexec must never close a caller-owned page/browser.
+      expect(page.isClosed()).toBe(false);
+      expect(browser.isConnected()).toBe(true);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("reuses one adopted page across sequential runs without re-binding errors", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>reuse</main>"
+    });
+    const browser = await chromium.launch();
+    try {
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+      const page = await context.newPage();
+      await page.goto("about:blank");
+
+      const first = await collectVitexec("console.log('run-1')", {
+        configFile: false,
+        root: currentProject.root,
+        page
+      });
+      const second = await collectVitexec("console.log('run-2')", {
+        configFile: false,
+        root: currentProject.root,
+        page
+      });
+
+      expect(first).toContain("[log] run-1");
+      // A second run on the same page must not throw "function already registered".
+      expect(second).toContain("[log] run-2");
+      expect(page.isClosed()).toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("runVitexecOnPage runs a snippet in a provided page without closing it", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>on-page</main>"
+    });
+    const browser = await chromium.launch();
+    try {
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+      const page = await context.newPage();
+      await page.goto("about:blank");
+
+      const logs: string[] = [];
+      for await (const line of runVitexecOnPage(
+        "console.log('via', document.querySelector('main')?.textContent)",
+        page,
+        { configFile: false, root: currentProject.root }
+      )) {
+        logs.push(line);
+      }
+
+      expect(logs.join("\n")).toContain("[log] via on-page");
+      expect(page.isClosed()).toBe(false);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("adopts a context (fresh page inside it) without closing the context", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>ctx</main>"
+    });
+    const browser = await chromium.launch();
+    try {
+      const context = await browser.newContext({ ignoreHTTPSErrors: true });
+
+      const output = await collectVitexec(
+        "console.log('ctx', document.querySelector('main')?.textContent)",
+        { configFile: false, root: currentProject.root, context }
+      );
+
+      expect(output).toContain("[log] ctx ctx");
+      // The caller-owned context (and browser) must stay open.
+      expect(browser.isConnected()).toBe(true);
+      expect(context.pages().length).toBeGreaterThan(0);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("adopts a browser (fresh context+page) and leaves the browser open", async () => {
+    currentProject = await createTempViteProject({
+      "index.html": "<main>br</main>"
+    });
+    const browser = await chromium.launch();
+    try {
+      const output = await collectVitexec(
+        "console.log('br', document.querySelector('main')?.textContent)",
+        { configFile: false, root: currentProject.root, browser }
+      );
+
+      expect(output).toContain("[log] br br");
+      // vitexec closes the context IT created, but never the adopted browser.
+      expect(browser.isConnected()).toBe(true);
+    } finally {
+      await browser.close();
+    }
   });
 
   it("sends generic GPU launch options to remote Playwright browser servers", () => {


### PR DESCRIPTION
Add an opt-in way to run a snippet in a browser/page the caller already owns, so a host (e.g. a dev server with a visible, instrumented tab) can run a vitexec check in that same browser — no second window. Fully backward compatible: with none of the new options, behavior is unchanged.

API: new RunVitexecOptions `page`, `adoptPage` (a thunk resolved AFTER the Vite server is listening, so a host that launches a browser in reaction to the server can hand it over), `context`, `browser`, and `keepBrowserOpen`; new export `runVitexecOnPage()`; new CLI flag/env `--keep-browser-open` / VITEXEC_KEEP_BROWSER_OPEN.

Internals: split browser acquisition from context/page creation and gate teardown on ownership — vitexec only closes handles it created itself, and always closes its own Vite server. A single idempotent `__vitexecReport` binding per page allows reusing one adopted page across sequential runs. When adopting an already-loaded page the injected runtime is 'armed' so the snippet runs exactly once (on vitexec's navigation, after the report hook is bound), never on the page's prior load.

Tests: page/context/browser adoption, sequential reuse, and runVitexecOnPage.

This contribution is funded by Meta Platforms, Inc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--keep-browser-open` CLI flag and `VITEXEC_KEEP_BROWSER_OPEN` environment variable to maintain browser sessions.
  * Added support for reusing existing Playwright pages, contexts, and browsers with vitexec.
  * Added `keepBrowserOpen` option to programmatic API.

* **Documentation**
  * Added guide for running vitexec with existing Playwright resources.

* **Tests**
  * Added coverage for page and browser adoption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->